### PR TITLE
export by animation name

### DIFF
--- a/client/export.lua
+++ b/client/export.lua
@@ -1,0 +1,57 @@
+local function playAnim(animDict, animName, duration, flags, introtiming, exittiming)
+    RequestAnimDict(animDict)
+
+    local t = 5
+    while not HasAnimDictLoaded(animDict) and t > 0 do
+        t = t - 1
+        Wait(300)
+    end
+
+    TaskPlayAnim(cache.ped, animDict, animName, tonumber(introtiming) or 1.0, tonumber(exittiming) or 1.0, duration or -1, flags or 1, 1, false, false, false, 0, true)
+    RemoveAnimDict(animDict)
+end
+
+local function findAnimation(animationName)
+    if type(animationName) ~= 'string' or animationName == '' then
+        return nil
+    end
+
+    local requestedName = animationName:lower()
+
+    for _, animation in pairs(Config.Animations) do
+        if animation.Label and animation.Label:lower() == requestedName then
+            return animation
+        end
+    end
+
+    return nil
+end
+
+local function playAnimationByName(animationName)
+    local animation = findAnimation(animationName)
+
+    if not animation then
+        return false, ('Animation "%s" was not found'):format(tostring(animationName))
+    end
+
+    ClearPedTasks(cache.ped)
+
+    if animation.Type == 'Anim' and animation.Dict and animation.Body then
+        playAnim(animation.Dict, animation.Body, -1, animation.Flag or 0)
+        return true
+    end
+
+    if animation.Type == 'Emote' and animation.EmoteType then
+        TaskEmote(cache.ped, 0, 2, joaat(animation.EmoteType), true, true, true, true, true)
+        return true
+    end
+
+    if animation.Type == 'Scenario' and animation.Scenario then
+        TaskStartScenarioInPlace(cache.ped, joaat(animation.Scenario), -1, true)
+        return true
+    end
+
+    return false, ('Animation "%s" has unsupported animation data'):format(animation.Label)
+end
+
+exports('PlayAnimation', playAnimationByName)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,7 +13,8 @@ shared_scripts {
 }
 
 client_scripts {
-    'client/client.lua'
+    'client/client.lua',
+    'client/export.lua'
 }
 
 server_scripts {


### PR DESCRIPTION
Made an export to use the animations for other scripts.
For example with consume, smoking a cigar or cigarette now calls the animations which handles the prop and everything.


Consume config and function that uses the new export.

        Smoke = {
            ['cigar'] = {
                item = 'cigar',
                hunger = 0,
                thirst = 0,
                stress = -10,
                propname = 'p_cigar01x',
            },
            ['cigarette'] = {
                item = 'cigarette',
                hunger = 0,
                thirst = 0,
                stress = -20,
                propname = 'p_cigarette_cs02x',
            },
        },

RegisterNetEvent('rsg-consume:client:smoke', function(itemName)
    if isBusy or not config.Consumables.Smoke[itemName] then return end

    local ped = getPed()
    local data = config.Consumables.Smoke[itemName]
    local smokeAnimations = {
        [GetHashKey('p_cigar01x')] = 'Smoke cigar',
        [GetHashKey('p_cigarette_cs02x')] = 'Smoke cigarette',
    }
    local animationName = smokeAnimations[GetHashKey(data.propname or '')]

    isBusy = true
    LocalPlayer.state:set("inv_busy", true, true)
    SetCurrentPedWeapon(ped, `WEAPON_UNARMED`)

    if animationName then
        exports['rsg-animations']:PlayAnimation(animationName)
    end

    TriggerServerEvent('rsg-consume:server:removeitem', data.item, 1)
    if data.hunger then TriggerEvent('hud:client:UpdateHunger', LocalPlayer.state.hunger + data.hunger) end
    if data.thirst then TriggerEvent('hud:client:UpdateThirst', LocalPlayer.state.thirst + data.thirst) end
    if data.stress and data.stress > 0 then TriggerEvent('hud:client:RelieveStress', data.stress) end
    TriggerEvent('rsg-consume:client:onConsume', data)
    LocalPlayer.state:set("inv_busy", false, true)
    isBusy = false
end)