### PR TITLE
export bug

### DIFF
--- a/client/export.lua
+++ b/client/export.lua
@@ -11,6 +11,24 @@ local function playAnim(animDict, animName, duration, flags, introtiming, exitti
     RemoveAnimDict(animDict)
 end
 
+local function normalizeBodyOption(bodyOption)
+    if type(bodyOption) == 'table' then
+        bodyOption = bodyOption.body
+    end
+
+    if type(bodyOption) ~= 'string' or bodyOption == '' then
+        return 'full'
+    end
+
+    bodyOption = bodyOption:lower()
+
+    if bodyOption == 'half' or bodyOption == 'upper' then
+        return 'half'
+    end
+
+    return 'full'
+end
+
 local function findAnimation(animationName)
     if type(animationName) ~= 'string' or animationName == '' then
         return nil
@@ -27,22 +45,37 @@ local function findAnimation(animationName)
     return nil
 end
 
-local function playAnimationByName(animationName)
+local function playEmote(emoteType, bodyMode)
+    if bodyMode == 'half' then
+        Citizen.InvokeNative(0xB31A277C1AC7B7FF, cache.ped, 0, 0, joaat(emoteType), 1, 1, 0, 0, 0)
+        return
+    end
+
+    Citizen.InvokeNative(0xB31A277C1AC7B7FF, cache.ped, 0, 2, joaat(emoteType), 0, 0, 0, 0, 0)
+end
+
+local function playAnimationByName(animationName, bodyOption)
     local animation = findAnimation(animationName)
+    local bodyMode = normalizeBodyOption(bodyOption)
 
     if not animation then
         return false, ('Animation "%s" was not found'):format(tostring(animationName))
     end
 
-    ClearPedTasks(cache.ped)
+    if bodyMode == 'half' then
+        ClearPedSecondaryTask(cache.ped)
+    else
+        ClearPedTasks(cache.ped)
+    end
 
     if animation.Type == 'Anim' and animation.Dict and animation.Body then
-        playAnim(animation.Dict, animation.Body, -1, animation.Flag or 0)
+        local flags = bodyMode == 'half' and (animation.HalfBodyFlag or 31) or (animation.FullBodyFlag or animation.Flag or 0)
+        playAnim(animation.Dict, animation.Body, -1, flags)
         return true
     end
 
     if animation.Type == 'Emote' and animation.EmoteType then
-        TaskEmote(cache.ped, 0, 2, joaat(animation.EmoteType), true, true, true, true, true)
+        playEmote(animation.EmoteType, bodyMode)
         return true
     end
 

--- a/client/export.lua
+++ b/client/export.lua
@@ -89,6 +89,7 @@ end
 
 exports('PlayAnimation', playAnimationByName)
 
+-- exports['rsg-animations']:PlayAnimation('Wave') -- defaults to full
 -- exports['rsg-animations']:PlayAnimation('Wave', 'full')
 -- animation does the full body.
 -- exports['rsg-animations']:PlayAnimation('Wave', 'upper')

--- a/client/export.lua
+++ b/client/export.lua
@@ -22,8 +22,8 @@ local function normalizeBodyOption(bodyOption)
 
     bodyOption = bodyOption:lower()
 
-    if bodyOption == 'half' or bodyOption == 'upper' then
-        return 'half'
+    if bodyOption == 'upper' then
+        return 'upper'
     end
 
     return 'full'
@@ -46,7 +46,7 @@ local function findAnimation(animationName)
 end
 
 local function playEmote(emoteType, bodyMode)
-    if bodyMode == 'half' then
+    if bodyMode == 'upper' then
         Citizen.InvokeNative(0xB31A277C1AC7B7FF, cache.ped, 0, 0, joaat(emoteType), 1, 1, 0, 0, 0)
         return
     end
@@ -62,14 +62,14 @@ local function playAnimationByName(animationName, bodyOption)
         return false, ('Animation "%s" was not found'):format(tostring(animationName))
     end
 
-    if bodyMode == 'half' then
+    if bodyMode == 'upper' then
         ClearPedSecondaryTask(cache.ped)
     else
         ClearPedTasks(cache.ped)
     end
 
     if animation.Type == 'Anim' and animation.Dict and animation.Body then
-        local flags = bodyMode == 'half' and (animation.HalfBodyFlag or 31) or (animation.FullBodyFlag or animation.Flag or 0)
+        local flags = bodyMode == 'upper' and (animation.HalfBodyFlag or 31) or (animation.FullBodyFlag or animation.Flag or 0)
         playAnim(animation.Dict, animation.Body, -1, flags)
         return true
     end
@@ -88,3 +88,8 @@ local function playAnimationByName(animationName, bodyOption)
 end
 
 exports('PlayAnimation', playAnimationByName)
+
+-- exports['rsg-animations']:PlayAnimation('Wave', 'full')
+-- animation does the full body.
+-- exports['rsg-animations']:PlayAnimation('Wave', 'upper')
+-- animation does only the upper of the body. Allows animations to be done on horse and other positions.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-animations'
-version '2.0.1'
+version '2.0.2'
 
 shared_scripts {
     '@ox_lib/init.lua',


### PR DESCRIPTION
sorry i found a bug when using it with consume on horseback. I updated the export to allow for nil, full and upper.

-- exports['rsg-animations']:PlayAnimation('Wave') -- defaults to full
-- exports['rsg-animations']:PlayAnimation('Wave', 'full')
-- animation does the full body.
-- exports['rsg-animations']:PlayAnimation('Wave', 'upper')
-- animation does only the upper of the body. Allows animations to be done on horse and other positions.



-- Updated consume to use the half body only so smoking can be done on horse back.
-- also added a clear task and wait for scenario exit since it cannot play in a scenario.
-- the 1 second loop works more reliably then 100 ms.

RegisterNetEvent('rsg-consume:client:smoke', function(itemName)
    if isBusy or not config.Consumables.Smoke[itemName] then return end

    local ped = getPed()
    local data = config.Consumables.Smoke[itemName]
    local smokeAnimations = {
        [GetHashKey('p_cigar01x')] = 'Smoke cigar',
        [GetHashKey('p_cigarette_cs02x')] = 'Smoke cigarette',
    }
    local animationName = smokeAnimations[GetHashKey(data.propname or '')]

    isBusy = true
    LocalPlayer.state:set("inv_busy", true, true)
    SetCurrentPedWeapon(ped, `WEAPON_UNARMED`)
    ClearPedTasks(ped)
    Wait(500)
    if IsPedExitingScenario(ped,0) == 1 then
        local loopCancel = 10
        while IsPedExitingScenario(ped,0) == 1 and loopCancel > 0 do
            loopCancel = loopCancel - 1
            Wait(1000)
        end
    end

    if animationName then
        exports['rsg-animations']:PlayAnimation(animationName,"upper")
    end

    TriggerServerEvent('rsg-consume:server:removeitem', data.item, 1)
    if data.hunger then TriggerEvent('hud:client:UpdateHunger', LocalPlayer.state.hunger + data.hunger) end
    if data.thirst then TriggerEvent('hud:client:UpdateThirst', LocalPlayer.state.thirst + data.thirst) end
    if data.stress and data.stress > 0 then TriggerEvent('hud:client:RelieveStress', data.stress) end
    TriggerEvent('rsg-consume:client:onConsume', data)
    LocalPlayer.state:set("inv_busy", false, true)
    isBusy = false
end)